### PR TITLE
Fix Mobile Display of Work Experience Page

### DIFF
--- a/src/Components/WorkExperience/WorkExperienceCard.css
+++ b/src/Components/WorkExperience/WorkExperienceCard.css
@@ -51,3 +51,14 @@
     margin-right: 20px;
   }
   
+  @media only screen and (max-width: 1024px) {
+    .container {
+      display: flex;
+    flex-flow: column;
+    align-items: center;
+    max-width: 1120px;
+    width: 90%;
+    margin: 0 auto;
+    }
+  }
+  


### PR DESCRIPTION
Issue:
Cards in WE page were displaying in 2 columns on mobile which worsened reading experience. Root Cause
Fixed min grid under hood for columns is 2
Solution
Override in CSS file

This fixes issue #33 